### PR TITLE
16383 reduce config migration whitespaces

### DIFF
--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -63,10 +63,6 @@ export async function applyPrettierFormatting(
   return prettier.format(content, options);
 }
 
-function isEqual(obj1: object, obj2: object): boolean {
-  return JSON.stringify(obj1) === JSON.stringify(obj2);
-}
-
 function extractValue(
   src: string,
   key: string,
@@ -115,22 +111,18 @@ function restoreUserFormat(
     if (!value || typeof value !== 'object') {
       continue;
     }
-    if (!isEqual(value, migrated[key as keyof typeof migrated])) {
-      continue;
-    }
 
     const search = extractValue(migratedRaw, key, value instanceof Array);
-    const replacement = extractValue(
-      originalRaw,
-      key,
-      value instanceof Array
-    )?.replace(/\$/g, '$$$'); // escape '$'
+    const replacement = extractValue(originalRaw, key, value instanceof Array); // escape '$'
 
     if (!search || !replacement) {
       continue;
     }
 
-    restored = restored.replace(search, replacement);
+    restored = restored.replace(
+      search,
+      restoreUserFormat(search, replacement, isJson5).replace(/\$/g, '$$$')
+    );
   }
 
   return restored;

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -238,7 +238,11 @@ export class MigratedDataFactory {
       let content: string;
 
       if (filename.endsWith('.json5')) {
-        content = JSON5.stringify(migratedConfig, undefined, indentSpace);
+        const userQuotes = raw!.match(/['"]/)?.[0] ?? '"';
+        content = JSON5.stringify(migratedConfig, {
+          space: indentSpace,
+          quote: userQuotes,
+        });
       } else {
         content = JSON.stringify(migratedConfig, undefined, indentSpace);
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Recursively restores user format when key value pairs(objects) or keys(arrays) are the same between the original config file and the migrated to be committed string. 

[json config migration](https://github.com/ladzaretti/feat-config-migration/pull/25/files)
[json5 config migration](https://github.com/ladzaretti/feat-config-migration-json5/pull/6/files)
[before config migrateion
](https://github.com/ladzaretti/feat-config-migration-before/pull/3/files)

![image](https://user-images.githubusercontent.com/97394622/179709606-27d8f0bc-0034-42ca-ba23-7abd2ba10426.png)
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/issues/16383
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
